### PR TITLE
BUGFIX: hexrgba breaks on undefined values

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = postcss.plugin('postcss-hexrgba', function () {
       css.walkDecls(function(decl) {
 
         // Only process rgba declaration values
-        if (decl.value.indexOf('rgba') === -1) {
+        if (typeof decl.value === 'undefined' || decl.value.indexOf('rgba') === -1) {
           return;
         }
 


### PR DESCRIPTION
Currently, the processor breaks at some CSS values that resolve to undefined (probably due to malformed CSS or something), that results in such errors:

```
ERROR in ./~/css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!./~/postcss-loader!./src/reset.css
Module build failed: TypeError: Cannot read property 'indexOf' of undefined
    at /home/dimaip/react-ui-components/node_modules/postcss-hexrgba/index.js:83:23
```

In any case, it's safer to check that the value is defined before processing it.