### PR TITLE
fix source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,11 +51,7 @@ module.exports = postcss.plugin('postcss-hexrgba', () => {
       return match.replace(matchHex, rgb);
     });
 
-    decl.replaceWith({
-      prop: decl.prop,
-      value: output,
-      important: decl.important
-    });
+    decl.value = output;
   }
 
   return function(css, result) {


### PR DESCRIPTION
before: 

```json
{
  "version": 3,
  "sources": ["../src/ChoiceItem.css", "<no source>"],
  "names": [],
  "mappings": "AAAA;EACE,oBAAa;EAAb,qBAAa;EAAb,iBAAa;EAAb,oBAAa;EAAb,aAAa;EACb,uBAA2B;EAA3B,mCAA2B;KAA3B,oBAA2B;MAA3B,oBAA2B;UAA3B,2BAA2B;AAC7B;;AAGE;IACE,kBAAkB;EACpB;;AAGE;MACE,kBAAkB;IACpB;;AAKF;IClBF,mDAAA;YAAA,2CAAA;EDoBE",
  "file": "ChoiceItem.css",
  "sourcesContent": [
    ".choice {\n  display: flex;\n  justify-content: flex-start;\n}\n\n.wrapper {\n  &:not(:last-of-type) {\n    margin-bottom: 4px;\n  }\n\n  &:last-child {\n    & .detail {\n      margin-bottom: 4px;\n    }\n  }\n}\n\n.input {\n  &:focus + label::before {\n    box-shadow: 0 0 0 2px rgba($Teal01, 0.2);\n  }\n}\n",
    null
  ]
}
```

Notice the `<no source>`, this breaks the source maps.

after

```json
{
  "version": 3,
  "sources": ["../src/ChoiceItem.css"],
  "names": [],
  "mappings": "AAAA;EACE,oBAAa;EAAb,qBAAa;EAAb,iBAAa;EAAb,oBAAa;EAAb,aAAa;EACb,uBAA2B;EAA3B,mCAA2B;KAA3B,oBAA2B;MAA3B,oBAA2B;UAA3B,2BAA2B;AAC7B;;AAGE;IACE,kBAAkB;EACpB;;AAGE;MACE,kBAAkB;IACpB;;AAKF;IACE,kDAAwC;YAAxC,0CAAwC;EAC1C",
  "file": "ChoiceItem.css",
  "sourcesContent": [
    ".choice {\n  display: flex;\n  justify-content: flex-start;\n}\n\n.wrapper {\n  &:not(:last-of-type) {\n    margin-bottom: 4px;\n  }\n\n  &:last-child {\n    & .detail {\n      margin-bottom: 4px;\n    }\n  }\n}\n\n.input {\n  &:focus + label::before {\n    box-shadow: 0 0 0 2px rgba($Teal01, 0.2);\n  }\n}\n"
  ]
}
```