### PR TITLE
Reduce npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test/
+.eslintrc
+.travis.yml


### PR DESCRIPTION
Your plugin is one of my favorites.

The common practice is to avoid development files from the npm package. A lot of users complain about `node_modules` size and this thing could reduce this size.

We do the same for PostCSS core and many plugins.