### PR TITLE
Use shortcuts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "rgba"
   ],
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/seaneking/postcss-hexrgba.git"
-  },
+  "repository": "seaneking/postcss-hexrgba",
   "author": "Sean King <sean@simpla.io>",
   "maintainers": [
     {
@@ -22,10 +19,6 @@
       "web": "http://simpla.io"
     }
   ],
-  "bugs": {
-    "url": "https://github.com/seaneking/postcss-hexrgba/issues"
-  },
-  "homepage": "https://github.com/seaneking/postcss-hexrgba",
   "dependencies": {
     "postcss": "^6.0.7"
   },


### PR DESCRIPTION
1. I used a shortcut for the `repository` field.
2. By default, npm will autogenerate the same `bugs` and `homepage` values if you have GitHub in `repository`