### PR TITLE
Speed up plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,23 +35,24 @@ module.exports = postcss.plugin('postcss-hexrgba', () => {
   function ruleHandler(decl, result) {
     let input = decl.value;
 
-    // Get the raw hex values and replace them
-    let output = input.replace(/rgba\(#(.*?),/g, (match, hex) => {
-      let rgb = hexRgb(hex),
-          matchHex = new RegExp('#' + hex);
+    if (input.includes('rgba(#')) {
+      // Get the raw hex values and replace them
+      let output = input.replace(/rgba\(#(.*?),/g, (match, hex) => {
+        let rgb = hexRgb(hex),
+            matchHex = new RegExp('#' + hex);
+          
+        // If conversion fails, emit a warning
+        if (!rgb) {
+          result.warn('not a valid hex', { node: decl });
+          return match;
+        }
+
+        rgb = rgb.toString();
         
-      // If conversion fails, emit a warning
-      if (!rgb) {
-        result.warn('not a valid hex', { node: decl });
-        return match;
-      }
-
-      rgb = rgb.toString();
-      
-      return match.replace(matchHex, rgb);
-    });
-
-    decl.value = output;
+        return match.replace(matchHex, rgb);
+      });
+      decl.value = output;
+    }
   }
 
   return function(css, result) {


### PR DESCRIPTION
RegExp is a pretty heavy call. Especially if `rgba(#` used rare.

In this PR I make plugin faster by calling RegExp only if we found `rgba(#` in the declaration by a quick search.

It is a popular technique used in Auutoprefixer and many other PostCSS plugins.