### PR TITLE
Add support for a space after open parenthesis

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ module.exports = postcss.plugin('postcss-hexrgba', () => {
   function ruleHandler(decl, result) {
     let input = decl.value;
 
-    if (input.includes('rgba(#')) {
+    if (input.includes('rgba(#') || input.includes('rgba( #')) {
       // Get the raw hex values and replace them
-      let output = input.replace(/rgba\(#(.*?),/g, (match, hex) => {
+      let output = input.replace(/rgba\( ?#(.*?),/g, (match, hex) => {
         let rgb = hexRgb(hex),
             matchHex = new RegExp('#' + hex);
           

--- a/test/fixtures/standard.css
+++ b/test/fixtures/standard.css
@@ -1,4 +1,5 @@
 .foo {
   color: rgba(#ffffff, 0.5);
   background: rgba(#00b2ff,.8);
+  border: rgba( #fff, .2 ) 1px solid;
 }

--- a/test/fixtures/standard.expected.css
+++ b/test/fixtures/standard.expected.css
@@ -1,4 +1,5 @@
 .foo {
   color: rgba(255,255,255, 0.5);
   background: rgba(0,178,255,.8);
+  border: rgba( 255,255,255, .2 ) 1px solid;
 }


### PR DESCRIPTION
`rgba(#fff, .75);` was converted but `rgba( #fff, .75 );` not.

See #17.